### PR TITLE
remove video-files from zipping

### DIFF
--- a/controllers/ZipController.php
+++ b/controllers/ZipController.php
@@ -369,7 +369,10 @@ class ZipController extends UploadController
     {
         $files = $this->getAllPostedFilesList();
         foreach ($files as $file) {
-            $this->archiveFile($file, $zipFile, $localPathPrefix, \humhub\modules\cfiles\models\File::getUserById($file->created_by)->username.'_'.$file->created_at.'_');
+            if ($file->getMimeBaseType() != 'video') {
+                $this->archiveFile($file, $zipFile, $localPathPrefix,
+                    \humhub\modules\cfiles\models\File::getUserById($file->created_by)->username . '_' . $file->created_at . '_');
+            }
         }
     }
 

--- a/views/browse/fileList.php
+++ b/views/browse/fileList.php
@@ -73,7 +73,9 @@ $parentFolderId = 0;
             data-url="<?php echo $downloadUrl; ?>"
             data-wall-url="<?php echo $wallUrl; ?>">
             <td class="text-muted text-right">
-                <?php echo Html::checkbox('selected[]', false, [ 'value' => $id, 'class' => 'multiselect']); ?>
+                <?php if($type != 'video') :?>
+                    <?php echo Html::checkbox('selected[]', false, [ 'value' => $id, 'class' => 'multiselect']); ?>
+                <?php endif;?>
             </td>
             <td class="text-left">
                 <div class="title">


### PR DESCRIPTION
If we have many video files on the wall and then will press "Zip all" button, we'll get:

`yii\base\ErrorException: Maximum execution time of 60 seconds exceeded in /humhub/protected/modules/cfiles/controllers/ZipController.php:426 Stack trace: #0 [internal function]: yii\base\ErrorHandler->handleFatalError() #1 {main}`.

In order to avoid such exception, it is necessary to remove video files from zipping.
Even if we set 'max_execution_time' to NO LIMIT apache will get the same exception.
