### PR TITLE
Enable default permissions

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -62,8 +62,8 @@ class Module extends ContentContainerModule
     {
         if ($contentContainer instanceof Space) {
             return [
-                new permissions\WriteAccess(),
-                new permissions\ManageFiles(),
+                new permissions\WriteAccess(['contentContainer' => $contentContainer]),
+                new permissions\ManageFiles(['contentContainer' => $contentContainer]),
             ];
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.13.0 - Unreleased
+---------------------------
+- Enh #4670: Enable default permissions
+
 0.12.1 - November 9, 2020
 ---------------------------
 - Fix #97: Don’t affect an update date and user on download counter action

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.13.0 - Unreleased
+0.12.2 - Unreleased
 ---------------------------
 - Enh #4670: Enable default permissions
 

--- a/module.json
+++ b/module.json
@@ -9,9 +9,9 @@
         "organisation",
         "sharing"
     ],
-    "version": "0.12.1",
+    "version": "0.13.0",
     "humhub": {
-        "minVersion": "1.7"
+        "minVersion": "1.8"
     },
     "homepage": "https://github.com/humhub/humhub-modules-cfiles",
     "authors": [

--- a/module.json
+++ b/module.json
@@ -9,9 +9,9 @@
         "organisation",
         "sharing"
     ],
-    "version": "0.13.0",
+    "version": "0.12.2",
     "humhub": {
-        "minVersion": "1.8"
+        "minVersion": "1.7"
     },
     "homepage": "https://github.com/humhub/humhub-modules-cfiles",
     "authors": [


### PR DESCRIPTION
Enable default permissions for Content Containers: Space and/or User

Issue: https://github.com/humhub/humhub/issues/4670
Reason described here https://github.com/humhub/humhub/issues/4670#issuecomment-735766589 after first screenshot.