### PR TITLE
Fix PHP error from deprecated search event removed in HumHub 1.19

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.18.3 - Unreleased
+-------------------
+- Fix #287: Fix PHP error from deprecated search event/constant removed in HumHub 1.19
+
 0.18.2 - July 20, 2026
 ----------------------
 - Fix #272: Fix Content linking with Comment

--- a/models/File.php
+++ b/models/File.php
@@ -11,7 +11,6 @@ use humhub\modules\file\libs\FileHelper;
 use humhub\modules\file\models\File as BaseFile;
 use humhub\modules\file\models\FileUpload;
 use humhub\modules\post\models\Post;
-use humhub\modules\search\events\SearchAddEvent;
 use humhub\modules\topic\models\Topic;
 use humhub\modules\user\models\User;
 use Yii;
@@ -135,7 +134,6 @@ class File extends FileSystemItem
         if ($this->baseFile) {
             $attributes['name'] = $this->getTitle();
         }
-        $this->trigger(self::EVENT_SEARCH_ADD, new SearchAddEvent($attributes));
         return $attributes;
     }
 

--- a/models/Folder.php
+++ b/models/Folder.php
@@ -8,7 +8,6 @@ use humhub\modules\file\libs\ImageHelper;
 use humhub\modules\file\models\FileContent;
 use humhub\modules\file\libs\FileHelper;
 use humhub\modules\user\models\User;
-use humhub\modules\search\events\SearchAddEvent;
 use humhub\modules\space\models\Space;
 use Yii;
 use yii\db\ActiveQuery;
@@ -162,7 +161,6 @@ class Folder extends FileSystemItem
                 $attributes['editor'] = $this->getEditor()->getDisplayName();
             }
         }
-        $this->trigger(self::EVENT_SEARCH_ADD, new SearchAddEvent($attributes));
         return $attributes;
     }
 

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
         "organisation",
         "sharing"
     ],
-    "version": "0.18.2",
+    "version": "0.18.3",
     "humhub": {
         "minVersion": "1.19"
     },


### PR DESCRIPTION
## Problem

`Folder::getSearchAttributes()` and `File::getSearchAttributes()` called:

```php
$this->trigger(self::EVENT_SEARCH_ADD, new SearchAddEvent($attributes));
```

`humhub\modules\search\events\SearchAddEvent` and the `EVENT_SEARCH_ADD` constant were deprecated since core 1.16 and **removed in core 1.19**. Since `develop` already requires `minVersion 1.19`, these calls fatal with an undefined constant + class-not-found error whenever the search index is built.

## Fix

The current search API (since 1.16) simply returns the attributes array from `getSearchAttributes()`. Removed the obsolete trigger calls and the now-unused `SearchAddEvent` imports in both models.

Ref: humhub/humhub-internal#1295